### PR TITLE
wrong handling of bit 11

### DIFF
--- a/src/File.php
+++ b/src/File.php
@@ -165,14 +165,10 @@ class File
             // Sets Bit 11: Language encoding flag (EFS).  If this bit is set,
             // the filename and comment fields for this file
             // MUST be encoded using UTF-8. (see APPENDIX D)
-            if (!mb_check_encoding($name, 'UTF-8') ||
-                !mb_check_encoding($comment, 'UTF-8')) {
-                throw new EncodingException(
-                    'File name and comment should use UTF-8 ' .
-                    'if one of them does not fit into ASCII range.'
-                );
+            if (mb_check_encoding($name, 'UTF-8') &&
+                mb_check_encoding($comment, 'UTF-8')) {
+                $this->bits |= self::BIT_EFS_UTF8;
             }
-            $this->bits |= self::BIT_EFS_UTF8;
         }
 
         if ($this->method->equals(Method::DEFLATE())) {


### PR DESCRIPTION
https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT


APPENDIX D - Language Encoding (EFS)
------------------------------------
...
D.2 If general purpose bit 11 is unset, the file name and comment SHOULD conform 
to the original ZIP character encoding.  If general purpose bit 11 is set, the 
filename and comment MUST support The Unicode Standard, Version 4.1.0 or 
greater using the character encoding form defined by the UTF-8 storage 
specification.  The Unicode Standard is published by the The Unicode
Consortium (www.unicode.org).  UTF-8 encoded data stored within ZIP files 
is expected to not include a byte order mark (BOM). 
...

----

For UTF-8 it is a MUST to set bit 11.
If it's not UTF-8, just don't set it and don't make it an exception.



